### PR TITLE
Seção 4 - Transações distrib - multidatasources, SpringBoot 3 e atomomikos 6

### DIFF
--- a/conteudo-complementar/transacional/pom.xml
+++ b/conteudo-complementar/transacional/pom.xml
@@ -24,7 +24,6 @@
 			<version>2.4.0</version>
 		</dependency>
 
-
 		<dependency>
 			<groupId>com.mysql</groupId>
 			<artifactId>mysql-connector-j</artifactId>
@@ -47,17 +46,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.atomikos</groupId>
-			<artifactId>transactions-jta</artifactId>
-			<version>4.0.6</version>
-		</dependency>
-		<dependency>
-			<groupId>com.atomikos</groupId>
-			<artifactId>transactions-jdbc</artifactId>
-			<version>4.0.6</version>
-		</dependency>
-
-		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
@@ -72,6 +60,26 @@
 			<artifactId>spring-batch-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+
+		<dependency>
+			<groupId>com.atomikos</groupId>
+			<artifactId>transactions-jta</artifactId>
+			<version>6.0.0</version>
+			<classifier>jakarta</classifier>
+		</dependency>
+		<dependency>
+			<groupId>com.atomikos</groupId>
+			<artifactId>transactions-jdbc</artifactId>
+			<version>6.0.0</version>
+		</dependency>
+		<dependency>
+			<groupId>jakarta.transaction</groupId>
+			<artifactId>jakarta.transaction-api</artifactId>
+			<version>2.0.1</version>
+		</dependency>
+
+
 	</dependencies>
 
 	<build>

--- a/conteudo-complementar/transacional/src/main/java/com/controle/transacional/config/DatasourceConfig.java
+++ b/conteudo-complementar/transacional/src/main/java/com/controle/transacional/config/DatasourceConfig.java
@@ -4,6 +4,7 @@ import com.atomikos.icatch.jta.UserTransactionImp;
 import com.atomikos.icatch.jta.UserTransactionManager;
 import com.atomikos.jdbc.AtomikosDataSourceBean;
 import com.mysql.cj.jdbc.MysqlXADataSource;
+import jakarta.transaction.SystemException;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -11,7 +12,6 @@ import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.jta.JtaTransactionManager;
 
@@ -21,64 +21,70 @@ import javax.sql.XADataSource;
 @Configuration
 public class DatasourceConfig {
 
-  @Primary
-  @Bean
-  @ConfigurationProperties(prefix = "spring.datasource")
-  public DataSource springDS() {
-    return DataSourceBuilder.create().build();
-  }
+    @Primary
+    @Bean
+    @ConfigurationProperties(prefix = "spring.datasource")
+    public DataSource springDS() {
+        return DataSourceBuilder.create().build();
+    }
 
+    @Bean
+    @ConfigurationProperties(prefix = "db1.datasource")
+    public DataSourceProperties db1Props() {
+        return new DataSourceProperties();
+    }
 
-  @Bean
-  @ConfigurationProperties(prefix = "db1.datasource")
-  public DataSourceProperties db1Props() {
-    return new DataSourceProperties();
-  }
+    @Bean
+    public DataSource db1AppDS(@Qualifier("db1Props") DataSourceProperties dsProps) {
+        XADataSource xaDataSource = createXaDataSource(dsProps);
+        AtomikosDataSourceBean bean = new AtomikosDataSourceBean();
+        bean.setUniqueResourceName("xaDB1");
+        bean.setXaDataSourceClassName("com.mysql.cj.jdbc.MysqlXADataSource");
+        bean.setLocalTransactionMode(true);
+        bean.setPoolSize(3);
+        bean.setXaDataSource(xaDataSource);
+        return bean;
+    }
 
-  @Bean
-  public DataSource db1AppDS(@Qualifier("db1Props") DataSourceProperties dsProps) {
-    XADataSource xaDataSource = createXaDataSource(dsProps);
+    @Bean
+    @ConfigurationProperties(prefix = "db2.datasource")
+    public DataSourceProperties db2Props() {
+        return new DataSourceProperties();
+    }
 
-    AtomikosDataSourceBean bean = new AtomikosDataSourceBean();
-    bean.setXaDataSource(xaDataSource);
-    bean.setUniqueResourceName("xaDB1");
+    @Bean
+    public DataSource db2AppDS(@Qualifier("db2Props") DataSourceProperties dsProps) {
+        XADataSource xaDataSource = createXaDataSource(dsProps);
+        AtomikosDataSourceBean bean = new AtomikosDataSourceBean();
+        bean.setUniqueResourceName("xaDB2");
+        bean.setXaDataSourceClassName("com.mysql.cj.jdbc.MysqlXADataSource");
+        bean.setLocalTransactionMode(true);
+        bean.setPoolSize(3);
+        bean.setXaDataSource(xaDataSource);
+        return bean;
+    }
 
-    return bean;
-  }
+    public XADataSource createXaDataSource(DataSourceProperties dsProps) {
+        MysqlXADataSource mysqlXADataSource = new MysqlXADataSource();
+        mysqlXADataSource.setURL(dsProps.getUrl());
+        mysqlXADataSource.setUser(dsProps.getUsername());
+        mysqlXADataSource.setPassword(dsProps.getPassword());
+        return mysqlXADataSource;
+    }
 
-  @Bean
-  @ConfigurationProperties(prefix = "db2.datasource")
-  public DataSourceProperties db2Props() {
-    return new DataSourceProperties();
-  }
+    public UserTransactionManager userTransactionManager() throws SystemException {
+        UserTransactionManager userTransactionManager = new UserTransactionManager();
+        userTransactionManager.setTransactionTimeout(300);
+        userTransactionManager.setForceShutdown(true);
+        return userTransactionManager;
+    }
 
-  @Bean
-  public DataSource db2AppDS(@Qualifier("db2Props") DataSourceProperties dsProps) {
-
-    XADataSource xaDataSource = createXaDataSource(dsProps);
-
-    AtomikosDataSourceBean bean = new AtomikosDataSourceBean();
-    bean.setXaDataSource(xaDataSource);
-    bean.setUniqueResourceName("xaDB2");
-
-    return bean;
-  }
-
-  @Bean
-  public PlatformTransactionManager transactionManager() {
-    UserTransactionManager userTransactionManager = new UserTransactionManager();
-    userTransactionManager.setForceShutdown(false);
-
-    UserTransactionImp userTransactionImp = new UserTransactionImp();
-
-    return new JtaTransactionManager(userTransactionImp, userTransactionManager);
-  }
-
-  public XADataSource createXaDataSource(DataSourceProperties dsProps) {
-    MysqlXADataSource mysqlXADataSource = new MysqlXADataSource();
-    mysqlXADataSource.setURL(dsProps.getUrl());
-    mysqlXADataSource.setUser(dsProps.getUsername());
-    mysqlXADataSource.setPassword(dsProps.getPassword());
-    return mysqlXADataSource;
-  }
+    @Bean
+    public PlatformTransactionManager jtaTransactionManager() throws SystemException {
+        JtaTransactionManager jtaTransactionManager = new JtaTransactionManager();
+        jtaTransactionManager.setTransactionManager(userTransactionManager()); //ref="userTransactionManager"
+        jtaTransactionManager.setUserTransaction(new UserTransactionImp()); //ref="userTransactionManager"
+        jtaTransactionManager.setAllowCustomIsolationLevels(true);
+        return jtaTransactionManager;
+    }
 }

--- a/conteudo-complementar/transacional/src/main/java/com/controle/transacional/step/PessoaStepConfig.java
+++ b/conteudo-complementar/transacional/src/main/java/com/controle/transacional/step/PessoaStepConfig.java
@@ -20,7 +20,7 @@ public class PessoaStepConfig {
 
     @Bean
     public Step stepPessoa(JobRepository jobRepository,
-                           PlatformTransactionManager transactionManager,
+                           @Qualifier("jtaTransactionManager") PlatformTransactionManager transactionManager,
                            ItemReader<Pessoa> reader,
                            ItemWriter writer,
                            TotalizadorStepListener stepListener,

--- a/conteudo-complementar/transacional/src/main/java/com/controle/transacional/writer/ItemWriterConfig.java
+++ b/conteudo-complementar/transacional/src/main/java/com/controle/transacional/writer/ItemWriterConfig.java
@@ -1,7 +1,6 @@
 package com.controle.transacional.writer;
 
 import com.controle.transacional.model.Pessoa;
-import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.batch.item.database.BeanPropertyItemSqlParameterSourceProvider;
 import org.springframework.batch.item.database.builder.JdbcBatchItemWriterBuilder;
@@ -23,7 +22,7 @@ public class ItemWriterConfig {
     }
 
     @Bean
-    public ItemWriter<Pessoa> writerPessoaDb1(@Qualifier("xaDB1") DataSource dataSource) {
+    public ItemWriter<Pessoa> writerPessoaDb1(@Qualifier("db1AppDS") DataSource dataSource) {
         return new JdbcBatchItemWriterBuilder<Pessoa>()
                 .dataSource(dataSource)
                 .sql("INSERT INTO pessoa (id, nome, email, data_nascimento, idade) VALUES (:id, :nome, :email, :dataNascimento, :idade)")
@@ -31,7 +30,7 @@ public class ItemWriterConfig {
                 .build();
     }
     @Bean
-    public ItemWriter<Pessoa> writerPessoaDb2(@Qualifier("xaDB2") DataSource dataSource) {
+    public ItemWriter<Pessoa> writerPessoaDb2(@Qualifier("db2AppDS") DataSource dataSource) {
         return new JdbcBatchItemWriterBuilder<Pessoa>()
                 .dataSource(dataSource)
                 .sql("INSERT INTO pessoa (id, nome, email, data_nascimento, idade) VALUES (:id, :nome, :email, :dataNascimento, :idade)")

--- a/conteudo-complementar/transacional/src/main/resources/jta.properties
+++ b/conteudo-complementar/transacional/src/main/resources/jta.properties
@@ -1,0 +1,1 @@
+com.atomikos.icatch.registered=true

--- a/primeirojobspringbatch/scripts_sql/root_privileges_manual.sh
+++ b/primeirojobspringbatch/scripts_sql/root_privileges_manual.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-until mysql -u root -proot -e "update mysql.user set host='%' where user='root'; flush privileges;"; do
+until mysql -u root -proot -e " update mysql.user set host='%' where user='root'; flush privileges; "; do
     echo "Aguardando o MySQL iniciar..."
     sleep 1
 done


### PR DESCRIPTION
Para transações distribuídas entre múltiplos Datasources  :

Com Spring Boot 2.x identifiquei que o atomikos até a versão 4.0 é compatível. 
Enquanto que a partir do Spring Boot 3 deve-se utilizar o atomikos 6.0 atendendo a jakarta ee 9